### PR TITLE
README contains `meke` command.

### DIFF
--- a/README
+++ b/README
@@ -9,7 +9,7 @@ http://github.com/masak/ufo and run
     ufo
     make
     make test
-    meke install
+    make install
 
 State:
 


### PR DESCRIPTION
`README` contains `meke` command. It should be `make`.
