### PR TITLE
Add unit declarator to class and grammar declarations

### DIFF
--- a/lib/XML/Parser/Tiny.pm6
+++ b/lib/XML/Parser/Tiny.pm6
@@ -4,7 +4,7 @@ use v6;
 use XML::Parser::Tiny::Grammar;
 use XML::Parser::Tiny::Actions;
 
-class XML::Parser::Tiny;
+unit class XML::Parser::Tiny;
 
 has $!grammar = XML::Parser::Tiny::Grammar;
 has $!actions = XML::Parser::Tiny::Actions.new;

--- a/lib/XML/Parser/Tiny/Actions.pm6
+++ b/lib/XML/Parser/Tiny/Actions.pm6
@@ -2,7 +2,7 @@
 
 use v6;
 
-class XML::Parser::Tiny::Actions;
+unit class XML::Parser::Tiny::Actions;
 
 method TOP ($/) {
   make {

--- a/lib/XML/Parser/Tiny/Grammar.pm6
+++ b/lib/XML/Parser/Tiny/Grammar.pm6
@@ -2,7 +2,7 @@
 
 use v6;
 
-grammar XML::Parser::Tiny::Grammar;
+unit grammar XML::Parser::Tiny::Grammar;
 
 token TOP {
     ^ <head> <.sp> <body_item> <.sp> $


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.