### PR TITLE
Set data to empty array when $<inner> is empty

### DIFF
--- a/lib/XML/Parser/Tiny/Actions.pm6
+++ b/lib/XML/Parser/Tiny/Actions.pm6
@@ -38,7 +38,7 @@ method long ($/) {
   make {
     name => $/.list[0].hash{'name'}.ast,
     attr => $<attribute>>>.ast.flat.hash,
-    data => $<inner>>>.ast.flat.grep({$_.defined}).unshift([]).reduce(
+    data => $<inner> eq [] ?? $<inner> !! $<inner>>>.ast.flat.grep({$_.defined}).unshift([]).reduce(
       sub (@lst, $curr) {
         if $curr.isa('Str') && @lst && @lst[@lst.end].isa('Str') {
           @lst[@lst.end] ~= $curr


### PR DESCRIPTION
A change to the internals of Rakudo (unfortunately, I don't know when,
however suspect in the 2013.02 release; see Rakudo changelog for details)
caused `$<inner>>>.ast` to return a `Parcel` instead of an `Array` in the case
that `$<inner>` was empty.  This caused the value in `data` to be `$([],)`
instead of simply `[]` which caused the equivalence tests in t/02-actions.t
to fail for the long form xml tags (the short form explicitly sets the data
property to the empty array, since it doesn't contain any data, and thus the
tests for the short form weren't affected).  By explicitly setting the data
part to the empty array when `$<inner>` is empty reinstates the original
functionality and the tests pass again.