### PR TITLE
Use kebab-case for test function names

### DIFF
--- a/t/03-parser.t
+++ b/t/03-parser.t
@@ -7,7 +7,7 @@ use XML::Parser::Tiny;
 
 my $parser = XML::Parser::Tiny.new;
 
-dies_ok( { $parser.parse('trash') } );
+dies-ok( { $parser.parse('trash') } );
 ok( $parser.parse('<doc />') eqv {head=>[],body =>{name =>'doc',attr =>{},data=>[]}} );
 
 done;


### PR DESCRIPTION
Test function names containing underscores are deprecated in favour of the
kebab-case versions.  This change brings the test functions up to date with
the current Rakudo test function naming conventions.