### PR TITLE
Throw structured exception.

### DIFF
--- a/lib/XML/Parser/Tiny.pm6
+++ b/lib/XML/Parser/Tiny.pm6
@@ -9,11 +9,16 @@ unit class XML::Parser::Tiny;
 has $!grammar = XML::Parser::Tiny::Grammar;
 has $!actions = XML::Parser::Tiny::Actions.new;
 
+class X::XML::Parser::Tiny::Invalid is Exception {
+    has $.source;
+    method message { "Input ($.source.chars() characters) is not a valid XML string" }
+}
+
 method parse (XML::Parser::Tiny:D: Str $xml) {
     if my $m = $!grammar.parse($xml, :$!actions) {
         return $m.ast;
     } else {
-        die 'Invalid XML';
+        X::XML::Parser::Tiny::Invalid.new(source => $xml).throw;
     }
 }
 

--- a/t/04-exception.t
+++ b/t/04-exception.t
@@ -1,0 +1,8 @@
+use v6;
+
+use Test;
+use XML::Parser::Tiny;
+
+throws-like { XML::Parser::Tiny.new.parse("<") }, X::XML::Parser::Tiny::Invalid;
+
+done-testing;


### PR DESCRIPTION
It makes easier to handle exception thrown by XML::Parser::Tiny.