### PR TITLE
Type constaraint for `self` is good practice.

### DIFF
--- a/lib/XML/Parser/Tiny.pm6
+++ b/lib/XML/Parser/Tiny.pm6
@@ -9,7 +9,7 @@ unit class XML::Parser::Tiny;
 has $!grammar = XML::Parser::Tiny::Grammar;
 has $!actions = XML::Parser::Tiny::Actions.new;
 
-method parse (Str $xml) {
+method parse (XML::Parser::Tiny:D: Str $xml) {
     if my $m = $!grammar.parse($xml, :$!actions) {
         return $m.ast;
     } else {

--- a/lib/XML/Parser/Tiny/Actions.pm6
+++ b/lib/XML/Parser/Tiny/Actions.pm6
@@ -38,16 +38,17 @@ method long ($/) {
   make {
     name => $/.list[0].hash{'name'}.ast,
     attr => $<attribute>>>.ast.flat.hash,
-    data => $<inner> eq [] ?? $<inner> !! $<inner>>>.ast.flat.grep({$_.defined}).unshift([]).reduce(
-      sub (@lst, $curr) {
-        if $curr.isa('Str') && @lst && @lst[@lst.end].isa('Str') {
-          @lst[@lst.end] ~= $curr
+    data => $<inner> eq [] ?? $<inner> !! do {
+      my $result = [];
+      for $<inner>>>.ast.flat.grep({$_.defined}) {
+        if $_ ~~ Str && $result && $result[$result.end] ~~ Str {
+          $result[$result.end] ~= $_;
         } else {
-          @lst.push($curr)
+          $result.push($_);
         }
-        return @lst;
       }
-    ),
+      $result;
+    },
   };
 }
 

--- a/t/01-grammar.t
+++ b/t/01-grammar.t
@@ -231,4 +231,4 @@ for %tests.kv -> $key, $val {
   ok($grammar.parse($key).Bool == $val);
 }
 
-done;
+done-testing;

--- a/t/02-actions.t
+++ b/t/02-actions.t
@@ -117,8 +117,8 @@ my $grammar = XML::Parser::Tiny::Grammar;
 my $actions = XML::Parser::Tiny::Actions.new;
 for %tests.kv -> $in, $out {
   my $m = $grammar.parse($in, :$actions);
-  ok($m.ast eqv $out); 
+  is($m.ast, $out, $in); 
 }
 
-done;
+done-testing;
 

--- a/t/03-parser.t
+++ b/t/03-parser.t
@@ -10,5 +10,5 @@ my $parser = XML::Parser::Tiny.new;
 dies-ok( { $parser.parse('trash') } );
 ok( $parser.parse('<doc />') eqv {head=>[],body =>{name =>'doc',attr =>{},data=>[]}} );
 
-done;
+done-testing;
 


### PR DESCRIPTION
Original code makes following message.

    $ perl6-m -Ilib -e 'use XML::Parser::Tiny; XML::Parser::Tiny.parse("<")'
    Cannot look up attributes in a type object
    in method parse at /home/tokuhirom/dev/p6-xml-parser-tiny/lib/XML/Parser/Tiny.pm6:15
    in block <unit> at -e:1

After this patch:

    $ perl6-m -Ilib -e 'use XML::Parser::Tiny; XML::Parser::Tiny.parse("<")'
    Invocant requires an instance of type XML::Parser::Tiny, but a type object was passed.  Did you forget a .new?
      in method parse at /home/tokuhirom/dev/p6-xml-parser-tiny/lib/XML/Parser/Tiny.pm6:17
      in block <unit> at -e:1

ref. http://design.perl6.org/S06.html#Parameters_with_type_constraints